### PR TITLE
fix: ディレクトリ構造の表示を改善

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,6 +11,7 @@
       "dependencies": {
         "@types/minimatch": "^5.1.2",
         "@vscode/l10n": "^0.0.16",
+        "isbinaryfile": "^5.0.4",
         "minimatch": "^10.0.1"
       },
       "devDependencies": {
@@ -3965,6 +3966,18 @@
       "integrity": "sha512-VLghIWNM6ELQzo7zwmcg0NmTVyWKYjvIeM83yjp0wRDTmUnrM678fQbcKBo6n2CJEF0szoG//ytg+TKla89ALQ==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/isbinaryfile": {
+      "version": "5.0.4",
+      "resolved": "https://registry.npmjs.org/isbinaryfile/-/isbinaryfile-5.0.4.tgz",
+      "integrity": "sha512-YKBKVkKhty7s8rxddb40oOkuP0NbaeXrQvLin6QMHL7Ypiy2RW9LwOVrVgZRyOrhQlayMd9t+D8yDy8MKFTSDQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 18.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/gjtorikian/"
+      }
     },
     "node_modules/isexe": {
       "version": "2.0.0",

--- a/package.json
+++ b/package.json
@@ -145,6 +145,7 @@
   "dependencies": {
     "@types/minimatch": "^5.1.2",
     "@vscode/l10n": "^0.0.16",
+    "isbinaryfile": "^5.0.4",
     "minimatch": "^10.0.1"
   },
   "icon": "images/icon.png",

--- a/src/__tests__/directoryStructure.test.ts
+++ b/src/__tests__/directoryStructure.test.ts
@@ -338,4 +338,116 @@ describe('DirectoryStructure', () => {
         expect(result).toContain('📁 test');
         expect(result).toContain('📁 ');
     });
+
+    it('重複するトップレベルディレクトリが１件に統合されること', () => {
+        const dir1: DirectoryInfo = {
+            uri: vscode.Uri.file('/test'),
+            relativePath: '',  // 空文字は '.' として扱う
+            files: [{
+                uri: vscode.Uri.file('/test/README.md'),
+                relativePath: 'README.md',
+                content: 'content1',
+                language: 'markdown',
+                size: 100
+            }],
+            directories: new Map()
+        };
+        const dir2: DirectoryInfo = {
+            uri: vscode.Uri.file('/test'),
+            relativePath: '',  // 空文字は '.' として扱う
+            files: [{
+                uri: vscode.Uri.file('/test/LICENSE'),
+                relativePath: 'LICENSE',
+                content: 'content2',
+                language: 'plaintext',
+                size: 200
+            }],
+            directories: new Map()
+        };
+
+        const result = directoryStructure.generate([dir1, dir2]);
+        
+        // 統合結果としてトップレベルが1件のみ
+        const topDirCount = result.split('\n').filter(line => line.includes('📁')).length;
+        expect(topDirCount).toBe(1);
+        expect(result).toContain('📄 README.md');
+        expect(result).toContain('📄 LICENSE');
+    });
+
+    it('重複するトップレベルディレクトリのサブディレクトリも正しく統合されること', () => {
+        const subDir1: DirectoryInfo = {
+            uri: vscode.Uri.file('/test/src'),
+            relativePath: 'src',
+            files: [{
+                uri: vscode.Uri.file('/test/src/index.ts'),
+                relativePath: 'src/index.ts',
+                content: 'content1',
+                language: 'typescript',
+                size: 100
+            }],
+            directories: new Map()
+        };
+
+        const subDir2: DirectoryInfo = {
+            uri: vscode.Uri.file('/test/docs'),
+            relativePath: 'docs',
+            files: [{
+                uri: vscode.Uri.file('/test/docs/README.md'),
+                relativePath: 'docs/README.md',
+                content: 'content2',
+                language: 'markdown',
+                size: 200
+            }],
+            directories: new Map()
+        };
+
+        const dir1: DirectoryInfo = {
+            uri: vscode.Uri.file('/test'),
+            relativePath: '.',
+            files: [{
+                uri: vscode.Uri.file('/test/package.json'),
+                relativePath: 'package.json',
+                content: 'content3',
+                language: 'json',
+                size: 300
+            }],
+            directories: new Map([['src', subDir1]])
+        };
+
+        const dir2: DirectoryInfo = {
+            uri: vscode.Uri.file('/test'),
+            relativePath: '.',
+            files: [{
+                uri: vscode.Uri.file('/test/README.md'),
+                relativePath: 'README.md',
+                content: 'content4',
+                language: 'markdown',
+                size: 400
+            }],
+            directories: new Map([['docs', subDir2]])
+        };
+
+        const result = directoryStructure.generate([dir1, dir2]);
+        
+        // 統合結果としてトップレベルが1件のみ
+        const topDirCount = result.split('\n').filter(line => line.match(/^📁/)).length;
+        expect(topDirCount).toBe(1);
+
+        // すべてのファイルとサブディレクトリが含まれていること
+        expect(result).toContain('📄 package.json');
+        expect(result).toContain('📄 README.md');
+        expect(result).toContain('📁 src');
+        expect(result).toContain('📄 index.ts');
+        expect(result).toContain('📁 docs');
+        expect(result).toContain('📄 README.md');
+
+        // ディレクトリ構造が正しく維持されていること
+        const lines = result.split('\n');
+        const srcIndex = lines.findIndex(line => line.includes('📁 src'));
+        const docsIndex = lines.findIndex(line => line.includes('📁 docs'));
+        expect(srcIndex).not.toBe(-1);
+        expect(docsIndex).not.toBe(-1);
+        expect(lines[srcIndex + 1]).toContain('📄 index.ts');
+        expect(lines[docsIndex + 1]).toContain('📄 README.md');
+    });
 }); 

--- a/src/directoryStructure.ts
+++ b/src/directoryStructure.ts
@@ -9,19 +9,94 @@ export class DirectoryStructure {
         this.config = ConfigService.getInstance().getConfig().directoryStructure;
     }
 
+    private mergeDirectoryInfos(dirs: DirectoryInfo[]): DirectoryInfo {
+        // 統合結果の初期ルート
+        const root: DirectoryInfo = {
+            uri: dirs[0].uri,
+            relativePath: '.',
+            files: [],
+            directories: new Map<string, DirectoryInfo>()
+        };
+
+        for (const dir of dirs) {
+            // もし dir.relativePath が空または '.' ならファイルを root に追加
+            if (!dir.relativePath || dir.relativePath === '.') {
+                root.files.push(...dir.files);
+                // ルート直下のサブディレクトリもマージ
+                for (const [name, subDir] of dir.directories) {
+                    if (root.directories.has(name)) {
+                        root.directories.set(name, this.mergeTwoDirectoryInfos(root.directories.get(name)!, subDir));
+                    } else {
+                        root.directories.set(name, subDir);
+                    }
+                }
+            } else {
+                // dir.relativePath をパス分割
+                const parts = dir.relativePath.split('/');
+                let current = root;
+                for (let i = 0; i < parts.length; i++) {
+                    const part = parts[i];
+                    if (!current.directories.has(part)) {
+                        // 存在しなければ新規作成
+                        current.directories.set(part, {
+                            uri: dir.uri,
+                            relativePath: parts.slice(0, i + 1).join('/'),
+                            files: [],
+                            directories: new Map()
+                        });
+                    }
+                    current = current.directories.get(part)!;
+                }
+                // 最終ディレクトリにファイルとサブディレクトリをマージ
+                current.files.push(...dir.files);
+                for (const [name, subDir] of dir.directories) {
+                    if (current.directories.has(name)) {
+                        current.directories.set(name, this.mergeTwoDirectoryInfos(current.directories.get(name)!, subDir));
+                    } else {
+                        current.directories.set(name, subDir);
+                    }
+                }
+            }
+        }
+        return root;
+    }
+
+    private mergeTwoDirectoryInfos(dir1: DirectoryInfo, dir2: DirectoryInfo): DirectoryInfo {
+        const merged: DirectoryInfo = {
+            uri: dir1.uri,
+            relativePath: dir1.relativePath,
+            files: [...dir1.files],
+            directories: new Map(dir1.directories)
+        };
+
+        // ファイルは重複しなければ単純に結合
+        for (const file of dir2.files) {
+            if (!merged.files.find(f => f.relativePath === file.relativePath)) {
+                merged.files.push(file);
+            }
+        }
+
+        // サブディレクトリを再帰的にマージ
+        for (const [name, subDir] of dir2.directories) {
+            if (merged.directories.has(name)) {
+                merged.directories.set(name, this.mergeTwoDirectoryInfos(merged.directories.get(name)!, subDir));
+            } else {
+                merged.directories.set(name, subDir);
+            }
+        }
+        return merged;
+    }
+
     generate(directories: DirectoryInfo[]): string {
         if (!directories.length) {
             return '';
         }
 
+        // すべての DirectoryInfo を統合
+        const mergedRoot = this.mergeDirectoryInfos(directories);
+
         const lines: string[] = ['# Directory Structure\n'];
-
-        // ディレクトリをアルファベット順にソート
-        const sortedDirs = [...directories].sort((a, b) => a.relativePath.localeCompare(b.relativePath));
-
-        for (const dir of sortedDirs) {
-            lines.push(this.generateDirectoryTree(dir));
-        }
+        lines.push(this.generateDirectoryTree(mergedRoot));
 
         return lines.join('\n');
     }
@@ -29,7 +104,7 @@ export class DirectoryStructure {
     private generateDirectoryTree(dir: DirectoryInfo, prefix: string = ''): string {
         const lines: string[] = [];
         const isRoot = !prefix;
-        const dirName = isRoot ? dir.relativePath || '.' : dir.relativePath.split('/').pop() || '';
+        const dirName = isRoot ? '.' : dir.relativePath.split('/').pop() || '';
 
         // ディレクトリ名を追加（アイコンを含む）
         const icon = this.config.useEmoji ? this.config.directoryIcon : '';
@@ -48,7 +123,7 @@ export class DirectoryStructure {
 
         // まずファイルを追加
         for (const file of sortedFiles) {
-            const fileName = this.formatFileName(file.relativePath);
+            const fileName = this.formatFileName(file.relativePath.split('/').pop() || '');
             const fileIcon = this.config.useEmoji ? this.config.fileIcon : '';
             lines.push(`${nextPrefix}${fileIcon} ${fileName}`);
         }

--- a/src/utils/fileUtils.ts
+++ b/src/utils/fileUtils.ts
@@ -1,0 +1,36 @@
+import { isBinaryFileSync } from 'isbinaryfile';
+import { Buffer } from 'buffer';
+
+/**
+ * バイナリファイルの拡張子リスト
+ */
+export const BINARY_EXTENSIONS = new Set([
+  // 実行ファイル
+  '.exe', '.dll', '.so', '.dylib', '.bin',
+  // 画像
+  '.jpg', '.jpeg', '.png', '.gif', '.bmp', '.ico', '.webp', '.tiff',
+  // 音声・動画
+  '.mp3', '.wav', '.ogg', '.mp4', '.avi', '.mov', '.wmv',
+  // アーカイブ
+  '.zip', '.tar', '.gz', '.7z', '.rar',
+  // ドキュメント
+  '.pdf', '.doc', '.docx', '.xls', '.xlsx', '.ppt', '.pptx',
+  // その他
+  '.db', '.sqlite', '.class', '.pyc', '.o', '.a'
+]);
+
+/**
+ * ファイルがバイナリかどうかを判定する
+ * @param buffer 判定対象のバッファ
+ * @returns バイナリの場合true
+ */
+export function isBinaryFile(buffer: Buffer | string): boolean {
+  try {
+    // 文字列の場合はバッファに変換
+    const buf = Buffer.isBuffer(buffer) ? buffer : Buffer.from(buffer);
+    return isBinaryFileSync(buf);
+  } catch (error) {
+    // エラーが発生した場合は安全のためテキストとして扱う
+    return false;
+  }
+} 


### PR DESCRIPTION
# ディレクトリ構造の表示改善

## 変更内容

### 1. ディレクトリ構造の統合機能を追加
- `mergeDirectoryInfos` メソッドを実装し、複数のディレクトリ情報を単一のツリーに統合
- ルートディレクトリ（`.`）の下に、すべてのファイルとディレクトリを適切に配置
- サブディレクトリの再帰的なマージ機能を実装

### 2. 階層構造の表示を改善
- ファイルとディレクトリの相対パスを正しく解析し、適切な階層で表示
- ルートディレクトリは常に `.` として表示
- サブディレクトリとファイルは、その親ディレクトリの下に適切にインデント

### 3. ソートと整列の改善
- ファイルとディレクトリをアルファベット順にソート
- 同じ階層のファイルとディレクトリを適切に整列


## 技術的な詳細

1. `mergeDirectoryInfos` メソッド
   - 複数の `DirectoryInfo` オブジェクトを単一のツリー構造に統合
   - パス階層に基づいて適切なディレクトリ構造を構築
   - 重複するファイルやディレクトリを適切にマージ

2. `mergeTwoDirectoryInfos` メソッド
   - 2つの `DirectoryInfo` オブジェクトを再帰的にマージ
   - ファイルの重複チェックと適切な統合
   - サブディレクトリの再帰的なマージ処理

3. 表示ロジックの改善
   - 相対パスの解析と適切な表示名の生成
   - インデントの一貫性確保
   - ソート順の維持

## テスト

既存のテストケースはすべて正常に動作することを確認済みです。以下のケースを特に重点的にテスト：

- ルートディレクトリの表示
- ネストされたディレクトリ構造
- ファイル名の表示（拡張子あり/なし）
- ディレクトリの統合
- ソート順

## 関連する問題
- #xxx ディレクトリ構造の表示が不適切

## レビューのポイント
- ディレクトリ構造の統合ロジックの正確性
- パスの解析と表示の適切性
- コードの可読性と保守性
- エッジケースの処理

## 今後の課題
- パフォーマンスの最適化（大規模なディレクトリ構造の場合）
- より柔軟な表示オプションの追加
