### PR TITLE
Escape file paths in Mermaid graph

### DIFF
--- a/src/__tests__/markdownGenerator.test.ts
+++ b/src/__tests__/markdownGenerator.test.ts
@@ -330,6 +330,45 @@ describe('MarkdownGenerator', () => {
                 expect(result).toContain('## test/another.js');
             });
 
+            test('ファイルパスに引用符が含まれている場合、エスケープされてMermaidグラフに含まれる', async () => {
+                mockConfig.get.mockImplementation((key: string, defaultValue?: any): any => {
+                    if (key === 'includeDependencies') return true;
+                    if (key === 'mermaid.maxNodes') return 300;
+                    if (key === 'prefixText') return '';
+                    if (key === 'enableCompression') return false;
+                    return defaultValue;
+                });
+
+                mockGenerateYaml.mockImplementation((_directoriesInfo: DirectoryInfo[], _options: ScanOptions): string => {
+                    const data = {
+                        files: [
+                            { relativePath: 'test/"weird".ts', imports: ['./utils.ts'] },
+                            { relativePath: 'test/utils.ts', imports: [] }
+                        ],
+                        dependencies: {
+                            'test/"weird".ts': ['test/utils.ts'],
+                            'test/utils.ts': []
+                        }
+                    };
+                    return yaml.dump(data);
+                });
+
+                const dirWithQuote: DirectoryInfo = {
+                    ...mockDirectoryInfo,
+                    files: [
+                        { ...mockFile, relativePath: 'test/"weird".ts', imports: ['./utils.ts'] },
+                        { ...mockFile, relativePath: 'test/utils.ts', imports: [] }
+                    ]
+                };
+
+                const result = await markdownGenerator.generate([dirWithQuote]);
+
+                expect(result).toContain('<!-- matomeru:auto-graph:start -->');
+                expect(result).toContain('flowchart TD');
+                expect(result).toContain('    "test/\\"weird\\".ts" --> "test/utils.ts"');
+                expect(result).toContain('<!-- matomeru:auto-graph:end -->');
+            });
+
             describe('maxNodes制限のテスト', () => {
                 const baseDirWithImports: DirectoryInfo = { // このテストスイート内で共通で使えるデータ
                     ...mockDirectoryInfo,

--- a/src/generators/MarkdownGenerator.ts
+++ b/src/generators/MarkdownGenerator.ts
@@ -19,6 +19,10 @@ export class MarkdownGenerator implements IGenerator {
         private readonly yamlGenerator: YamlGenerator = new YamlGenerator()
     ) {}
 
+    private escapeMermaidLabel(label: string): string {
+        return label.replace(/\\/g, '\\\\').replace(/"/g, '\\"');
+    }
+
     async generate(directories: DirectoryInfo[]): Promise<string> {
         if (!directories.length) {
             return '';
@@ -180,10 +184,12 @@ export class MarkdownGenerator implements IGenerator {
         const edges: { from: string, to: string }[] = [];
 
         for (const sourceFile in dependencies) {
-            nodes.add(`    "${sourceFile}"`);
+            const escapedSource = this.escapeMermaidLabel(sourceFile);
+            nodes.add(escapedSource);
             for (const targetFile of dependencies[sourceFile]) {
-                nodes.add(`    "${targetFile}"`);
-                edges.push({ from: sourceFile, to: targetFile });
+                const escapedTarget = this.escapeMermaidLabel(targetFile);
+                nodes.add(escapedTarget);
+                edges.push({ from: escapedSource, to: escapedTarget });
             }
         }
         // eslint-disable-next-line no-console


### PR DESCRIPTION
## Summary
- handle backslashes and quotes when embedding paths in Mermaid
- test escaping of file paths containing quotes

## Testing
- `npm test`