### PR TITLE
Use logger debug in MarkdownGenerator

### DIFF
--- a/src/__tests__/logger.test.ts
+++ b/src/__tests__/logger.test.ts
@@ -72,6 +72,27 @@ describe('Logger', () => {
         });
     });
 
+    describe('debug', () => {
+        it('DEBUGレベルでメッセージをログ出力する', () => {
+            logger.debug('Test debug message');
+            expect(mockOutputChannel.appendLine).toHaveBeenCalledWith(
+                expect.stringMatching(/^\[\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}\.\d{3}Z\] \[DEBUG\] \[TestContext\] Test debug message$/)
+            );
+        });
+
+        it('開発環境ではconsole.logも使用する', () => {
+            const mockConsoleLog = jest.spyOn(console, 'log').mockImplementation();
+            process.env.NODE_ENV = 'development';
+
+            logger.debug('Test debug message');
+
+            expect(mockConsoleLog).toHaveBeenCalledWith(
+                expect.stringMatching(/^\[\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}\.\d{3}Z\] \[DEBUG\] \[TestContext\] Test debug message$/)
+            );
+            mockConsoleLog.mockRestore();
+        });
+    });
+
     describe('warn', () => {
         it('WARNレベルでメッセージをログ出力し、警告を表示する', () => {
             const message = 'Test warning message';

--- a/src/generators/MarkdownGenerator.ts
+++ b/src/generators/MarkdownGenerator.ts
@@ -29,31 +29,24 @@ export class MarkdownGenerator implements IGenerator {
         }
 
         const config = vscode.workspace.getConfiguration('matomeru');
-        // eslint-disable-next-line no-console
-        console.log('--- MarkdownGenerator Config Check ---');
-        // eslint-disable-next-line no-console
-        console.log('matomeru.markdown.prefixText:', config.get<string>('markdown.prefixText'));
-        // eslint-disable-next-line no-console
-        console.log('matomeru.includeDependencies:', config.get<boolean>('includeDependencies'));
-        // eslint-disable-next-line no-console
-        console.log('matomeru.mermaid.maxNodes:', config.get<number>('mermaid.maxNodes'));
+        logger.debug('--- MarkdownGenerator Config Check ---');
+        logger.debug(`matomeru.markdown.prefixText: ${config.get<string>('markdown.prefixText')}`);
+        logger.debug(`matomeru.includeDependencies: ${config.get<boolean>('includeDependencies')}`);
+        logger.debug(`matomeru.mermaid.maxNodes: ${config.get<number>('mermaid.maxNodes')}`);
 
         let finalMarkdown = '';
 
         const prefixText = config.get<string>('prefixText', '');
         if (prefixText) {
-            // eslint-disable-next-line no-console
-            console.log('Applying prefixText:', prefixText.substring(0, 50) + (prefixText.length > 50 ? '...' : ''));
+            logger.debug('Applying prefixText: ' + prefixText.substring(0, 50) + (prefixText.length > 50 ? '...' : ''));
             finalMarkdown += prefixText + '\n';
         }
 
         if (config.get<boolean>('includeDependencies')) {
-            // eslint-disable-next-line no-console
-            console.log('Attempting to generate Mermaid graph...');
+            logger.debug('Attempting to generate Mermaid graph...');
             try {
                 const mermaidGraphString = await this.generateMermaidGraph(directories, config);
-                // eslint-disable-next-line no-console
-                console.log('Generated mermaidGraphString:', mermaidGraphString ? mermaidGraphString.substring(0, 100) + '...' : 'EMPTY_GRAPH');
+                logger.debug('Generated mermaidGraphString: ' + (mermaidGraphString ? mermaidGraphString.substring(0, 100) + '...' : 'EMPTY_GRAPH'));
                 if (mermaidGraphString) {
                     finalMarkdown += MERMAID_GRAPH_START_COMMENT + '\n';
                     finalMarkdown += '```mermaid\n';
@@ -64,12 +57,10 @@ export class MarkdownGenerator implements IGenerator {
                 }
             } catch (error) {
                 logger.error(`Failed to generate Mermaid graph: ${error instanceof Error ? error.message : String(error)}`);
-                 // eslint-disable-next-line no-console
-                console.error('Error during generateMermaidGraph:', error);
+                logger.error(`Error during generateMermaidGraph: ${error instanceof Error ? error.message : String(error)}`);
             }
         } else {
-            // eslint-disable-next-line no-console
-            console.log('Skipping Mermaid graph generation (includeDependencies is false).');
+            logger.debug('Skipping Mermaid graph generation (includeDependencies is false).');
         }
         
         const coreContentSections: string[] = [];
@@ -94,7 +85,7 @@ export class MarkdownGenerator implements IGenerator {
         finalMarkdown += coreMarkdown;
         
         // eslint-disable-next-line no-console
-        // console.log('Final markdown output (first 200 chars):\n', finalMarkdown.substring(0,200));
+        // logger.debug('Final markdown output (first 200 chars):\n' + finalMarkdown.substring(0,200));
 
         return finalMarkdown;
     }
@@ -161,18 +152,18 @@ export class MarkdownGenerator implements IGenerator {
 
     private async generateMermaidGraph(directories: DirectoryInfo[], config: vscode.WorkspaceConfiguration): Promise<string> {
         // eslint-disable-next-line no-console
-        // console.log('generateMermaidGraph called with config for includeDependencies:', config.get('includeDependencies'));
+        // logger.debug('generateMermaidGraph called with config for includeDependencies: ' + config.get('includeDependencies'));
         const yamlString = await this.yamlGenerator.generate(directories);
         // eslint-disable-next-line no-console
-        // console.log('yamlGenerator.generate returned (first 100 chars):', typeof yamlString === 'string' ? yamlString.substring(0,100) + '...' : yamlString);
+        // logger.debug('yamlGenerator.generate returned (first 100 chars): ' + (typeof yamlString === 'string' ? yamlString.substring(0,100) + '...' : yamlString));
         const parsedYaml: any = yaml.load(yamlString);
         // eslint-disable-next-line no-console
-        // console.log('Parsed YAML dependencies (type):', typeof parsedYaml?.dependencies, 'Value:', parsedYaml?.dependencies ? JSON.stringify(parsedYaml.dependencies).substring(0,100) + '...' : 'N/A');
+        // logger.debug('Parsed YAML dependencies (type): ' + typeof parsedYaml?.dependencies + ' Value: ' + (parsedYaml?.dependencies ? JSON.stringify(parsedYaml.dependencies).substring(0,100) + '...' : 'N/A'));
 
 
         if (!parsedYaml || typeof parsedYaml.dependencies !== 'object' || parsedYaml.dependencies === null) {
             // eslint-disable-next-line no-console
-            // console.log('No valid dependencies found in parsed YAML, returning empty graph.');
+            // logger.debug('No valid dependencies found in parsed YAML, returning empty graph.');
             return '';
         }
 
@@ -193,7 +184,7 @@ export class MarkdownGenerator implements IGenerator {
             }
         }
         // eslint-disable-next-line no-console
-        // console.log(`Mermaid: Calculated ${nodes.size} nodes, ${edges.length} edges. Max nodes: ${maxNodes}`);
+        // logger.debug(`Mermaid: Calculated ${nodes.size} nodes, ${edges.length} edges. Max nodes: ${maxNodes}`);
 
         let truncated = false;
         if (nodes.size > maxNodes) {

--- a/src/utils/logger.ts
+++ b/src/utils/logger.ts
@@ -17,6 +17,10 @@ export class Logger {
         return Logger.instance;
     }
 
+    debug(message: string): void {
+        this.log('DEBUG', message);
+    }
+
     info(message: string): void {
         this.log('INFO', message);
     }


### PR DESCRIPTION
## Summary
- add `debug` level to logger
- update markdown generator to use logger for debug/error messages
- cover new debug method in tests

## Testing
- `npm test`